### PR TITLE
Feat/getUserProperties

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+- Added `getUserProperties` to decorated `fastify.Request`, which returns the user properties
+
 ### Changed
 
 - Update @mia-platform/lc39 2.2.2 -> 2.4.0

--- a/README.md
+++ b/README.md
@@ -80,7 +80,7 @@ to validate the querystring, the parameters, the payload, the response.
 In addition to validation, you will also have a swagger documentation available at the `/documentation/` path.
 
 Thanks to TypeScript's type definitions, editors can actually provide autocompletion for the additional methods
-of the request object such as `getUserId` or `getGroups` and `getUserProperties`
+of the request object such as `getUserId` or `getGroups` or `getUserProperties`
 
 In the async initialization function you can also access the `fastify` instance, so you can register any plugin,
 see [here][fastify-ecosystem] for a list of currently available plugins.  

--- a/README.md
+++ b/README.md
@@ -80,7 +80,7 @@ to validate the querystring, the parameters, the payload, the response.
 In addition to validation, you will also have a swagger documentation available at the `/documentation/` path.
 
 Thanks to TypeScript's type definitions, editors can actually provide autocompletion for the additional methods
-of the request object such as `getUserId` or `getGroups`.
+of the request object such as `getUserId` or `getGroups` and `getUserProperties`
 
 In the async initialization function you can also access the `fastify` instance, so you can register any plugin,
 see [here][fastify-ecosystem] for a list of currently available plugins.  

--- a/examples/default.env
+++ b/examples/default.env
@@ -1,4 +1,5 @@
 USERID_HEADER_KEY=userid-header-key
+USER_PROPERTIES_HEADER_KEY=miauserproperties
 GROUPS_HEADER_KEY=groups-header-key
 CLIENTTYPE_HEADER_KEY=clienttype-header-key
 BACKOFFICE_HEADER_KEY=backoffice-header-key

--- a/index.d.ts
+++ b/index.d.ts
@@ -16,7 +16,6 @@
 
 import * as fastify from 'fastify'
 import * as http from 'http'
-import { EmptyStatement } from 'typescript'
 
 export = customPlugin
 

--- a/index.d.ts
+++ b/index.d.ts
@@ -16,6 +16,7 @@
 
 import * as fastify from 'fastify'
 import * as http from 'http'
+import { EmptyStatement } from 'typescript'
 
 export = customPlugin
 
@@ -41,7 +42,7 @@ declare namespace customPlugin {
     'bodyLimit' |
     'logLevel' |
     'config' |
-    'prefixTrailingSlash' 
+    'prefixTrailingSlash'
   >
 
   interface DecoratedFastify extends fastify.FastifyInstance {
@@ -55,12 +56,14 @@ declare namespace customPlugin {
 
   interface DecoratedRequest extends fastify.FastifyRequest<http.IncomingMessage> {
     getUserId: () => string | null,
+    getUserProperties: () => object,
     getGroups: () => string[],
     getClientType: () => string | null,
     isFromBackOffice: () => boolean,
     getDirectServiceProxy: (serviceName: string, options?: InitServiceOptions) => Service,
     getServiceProxy: (options?: InitServiceOptions) => Service,
     USERID_HEADER_KEY: string,
+    USER_PROPERTIES_HEADER_KEY: string,
     GROUPS_HEADER_KEY: string,
     CLIENTTYPE_HEADER_KEY: string,
     BACKOFFICE_HEADER_KEY: string

--- a/index.d.ts
+++ b/index.d.ts
@@ -55,7 +55,7 @@ declare namespace customPlugin {
 
   interface DecoratedRequest extends fastify.FastifyRequest<http.IncomingMessage> {
     getUserId: () => string | null,
-    getUserProperties: () => object,
+    getUserProperties: () => object | null,
     getGroups: () => string[],
     getClientType: () => string | null,
     isFromBackOffice: () => boolean,

--- a/index.js
+++ b/index.js
@@ -144,9 +144,11 @@ function getServiceBuilderFromService(baseOptions = {}) {
   return serviceBuilder(this[MICROSERVICE_GATEWAY_SERVICE_NAME], {}, baseOptions)
 }
 
+// TODO: test this
 function getMiaHeaders() {
   return {
     [this.USERID_HEADER_KEY]: this.getUserId(),
+    [this.USER_PROPERTIES_HEADER_KEY]: JSON.stringify(this.getUserProperties()),
     [this.GROUPS_HEADER_KEY]: this.getGroups().join(','),
     [this.CLIENTTYPE_HEADER_KEY]: this.getClientType(),
     [this.BACKOFFICE_HEADER_KEY]: this.isFromBackOffice() ? '1' : '',

--- a/index.js
+++ b/index.js
@@ -29,6 +29,7 @@ const addPreDecorator = require('./lib/preDecorator')
 const addPostDecorator = require('./lib/postDecorator')
 
 const USERID_HEADER_KEY = 'USERID_HEADER_KEY'
+const USER_PROPERTIES_HEADER_KEY = 'USER_PROPERTIES_HEADER_KEY'
 const GROUPS_HEADER_KEY = 'GROUPS_HEADER_KEY'
 const CLIENTTYPE_HEADER_KEY = 'CLIENTTYPE_HEADER_KEY'
 const BACKOFFICE_HEADER_KEY = 'BACKOFFICE_HEADER_KEY'
@@ -51,6 +52,12 @@ const baseSchema = {
       type: 'string',
       description: 'the header key to get the user id',
       minLength: 1,
+    },
+    [USER_PROPERTIES_HEADER_KEY]: {
+      type: 'string',
+      description: 'the header key to get the user permissions',
+      minLength: 1,
+      deafult: 'miauserproperties',
     },
     [GROUPS_HEADER_KEY]: {
       type: 'string',
@@ -157,6 +164,7 @@ async function decorateRequestAndFastifyInstance(fastify, { asyncInitFunction })
   fastify.setSchemaCompiler(schema => ajv.compile(schema))
 
   fastify.decorateRequest(USERID_HEADER_KEY, config[USERID_HEADER_KEY])
+  fastify.decorateRequest(USER_PROPERTIES_HEADER_KEY, config[USER_PROPERTIES_HEADER_KEY])
   fastify.decorateRequest(GROUPS_HEADER_KEY, config[GROUPS_HEADER_KEY])
   fastify.decorateRequest(CLIENTTYPE_HEADER_KEY, config[CLIENTTYPE_HEADER_KEY])
   fastify.decorateRequest(BACKOFFICE_HEADER_KEY, config[BACKOFFICE_HEADER_KEY])

--- a/index.js
+++ b/index.js
@@ -57,7 +57,7 @@ const baseSchema = {
       type: 'string',
       description: 'the header key to get the user permissions',
       minLength: 1,
-      deafult: 'miauserproperties',
+      default: 'miauserproperties',
     },
     [GROUPS_HEADER_KEY]: {
       type: 'string',

--- a/lib/postDecorator.js
+++ b/lib/postDecorator.js
@@ -19,10 +19,14 @@
 const LEAVE_UNCHANGED_RESPONSE_STATUS_CODE = 204
 const ABORT_CHAIN_STATUS_CODE = 418
 
-const { getUserId, getGroups, getClientType, isFromBackOffice } = require('./util')
+const { getUserId, getGroups, getClientType, isFromBackOffice, getUserProperties } = require('./util')
 
 function getUserIdFromBody() {
   return getUserId(this.getOriginalRequestHeaders()[this.USERID_HEADER_KEY])
+}
+
+function getUserPropertiesFromBody() {
+  return getUserProperties(this.getOriginalRequestHeaders()[this.USER_PROPERTIES_HEADER_KEY])
 }
 
 function getGroupsFromBody() {
@@ -179,6 +183,7 @@ function addPostDecorator(path, handler) {
     fastify.decorateRequest('getOriginalResponseStatusCode', getResponseStatusCode)
 
     fastify.decorateRequest('getUserId', getUserIdFromBody)
+    fastify.decorateRequest('getUserProperties', getUserPropertiesFromBody)
     fastify.decorateRequest('getGroups', getGroupsFromBody)
     fastify.decorateRequest('getClientType', getClientTypeFromBody)
     fastify.decorateRequest('isFromBackOffice', isFromBackOfficeFromBody)
@@ -200,7 +205,7 @@ function addPostDecorator(path, handler) {
 
 addPostDecorator[Symbol.for('plugin-meta')] = {
   decorators: {
-    request: ['USERID_HEADER_KEY', 'GROUPS_HEADER_KEY', 'CLIENTTYPE_HEADER_KEY', 'BACKOFFICE_HEADER_KEY'],
+    request: ['USERID_HEADER_KEY', 'USER_PROPERTIES_HEADER_KEY', 'GROUPS_HEADER_KEY', 'CLIENTTYPE_HEADER_KEY', 'BACKOFFICE_HEADER_KEY'],
   },
 }
 

--- a/lib/preDecorator.js
+++ b/lib/preDecorator.js
@@ -19,10 +19,14 @@
 const LEAVE_UNCHANGED_REQUEST_STATUS_CODE = 204
 const ABORT_CHAIN_STATUS_CODE = 418
 
-const { getUserId, getGroups, getClientType, isFromBackOffice } = require('./util')
+const { getUserId, getGroups, getClientType, isFromBackOffice, getUserProperties } = require('./util')
 
 function getUserIdFromBody() {
   return getUserId(this.getOriginalRequestHeaders()[this.USERID_HEADER_KEY])
+}
+
+function getUserPropertiesFromBody() {
+  return getUserProperties(this.getOriginalRequestHeaders()[this.USER_PROPERTIES_HEADER_KEY])
 }
 
 function getGroupsFromBody() {
@@ -147,6 +151,7 @@ function addPreDecorator(path, handler) {
     fastify.decorateRequest('getOriginalRequestBody', getBody)
 
     fastify.decorateRequest('getUserId', getUserIdFromBody)
+    fastify.decorateRequest('getUserProperties', getUserPropertiesFromBody)
     fastify.decorateRequest('getGroups', getGroupsFromBody)
     fastify.decorateRequest('getClientType', getClientTypeFromBody)
     fastify.decorateRequest('isFromBackOffice', isFromBackOfficeFromBody)
@@ -168,7 +173,7 @@ function addPreDecorator(path, handler) {
 
 addPreDecorator[Symbol.for('plugin-meta')] = {
   decorators: {
-    request: ['USERID_HEADER_KEY', 'GROUPS_HEADER_KEY', 'CLIENTTYPE_HEADER_KEY', 'BACKOFFICE_HEADER_KEY'],
+    request: ['USERID_HEADER_KEY', 'USER_PROPERTIES_HEADER_KEY', 'GROUPS_HEADER_KEY', 'CLIENTTYPE_HEADER_KEY', 'BACKOFFICE_HEADER_KEY'],
   },
 }
 

--- a/lib/rawCustomPlugin.js
+++ b/lib/rawCustomPlugin.js
@@ -16,10 +16,14 @@
 
 'use strict'
 
-const { getUserId, getGroups, getClientType, isFromBackOffice } = require('./util')
+const { getUserId, getGroups, getClientType, isFromBackOffice, getUserProperties } = require('./util')
 
 function getUserIdFromHeader() {
   return getUserId(this.headers[this.USERID_HEADER_KEY])
+}
+
+function getUserPropertiesFromHeader() {
+  return getUserProperties(this.headers[this.USER_PROPERTIES_HEADER_KEY])
 }
 
 function getGroupsFromHeaders() {
@@ -37,6 +41,7 @@ function isFromBackOfficeFromHeaders() {
 function addRawCustomPlugin(method, path, handler, schema, advancedConfigs) {
   this.register(function rawCustomPlugin(fastify, options, next) {
     fastify.decorateRequest('getUserId', getUserIdFromHeader)
+    fastify.decorateRequest('getUserProperties', getUserPropertiesFromHeader)
     fastify.decorateRequest('getGroups', getGroupsFromHeaders)
     fastify.decorateRequest('getClientType', getClientTypeFromHeaders)
     fastify.decorateRequest('isFromBackOffice', isFromBackOfficeFromHeaders)
@@ -49,7 +54,7 @@ function addRawCustomPlugin(method, path, handler, schema, advancedConfigs) {
 
 addRawCustomPlugin[Symbol.for('plugin-meta')] = {
   decorators: {
-    request: ['USERID_HEADER_KEY', 'GROUPS_HEADER_KEY', 'CLIENTTYPE_HEADER_KEY', 'BACKOFFICE_HEADER_KEY', 'ADDITIONAL_HEADERS_TO_PROXY'],
+    request: ['USERID_HEADER_KEY', 'USER_PROPERTIES_HEADER_KEY', 'GROUPS_HEADER_KEY', 'CLIENTTYPE_HEADER_KEY', 'BACKOFFICE_HEADER_KEY', 'ADDITIONAL_HEADERS_TO_PROXY'],
   },
 }
 

--- a/lib/util.js
+++ b/lib/util.js
@@ -29,6 +29,20 @@ function getUserId(userId) {
   return userId
 }
 
+function getUserProperties(userPropertiesAsString) {
+  let result = {}
+  if (!userPropertiesAsString) {
+    return result
+  }
+
+  try {
+    result = JSON.parse(userPropertiesAsString)
+  } catch (error) {
+    // TODO: handle error?
+  }
+  return result
+}
+
 function getGroups(groups) {
   return groups.split(',').filter(longerThan(0))
 }
@@ -53,6 +67,7 @@ const extraHeadersKeys = [
 
 module.exports = {
   getUserId,
+  getUserProperties,
   getGroups,
   getClientType,
   isFromBackOffice,

--- a/lib/util.js
+++ b/lib/util.js
@@ -30,17 +30,15 @@ function getUserId(userId) {
 }
 
 function getUserProperties(userPropertiesAsString) {
-  let result = {}
   if (!userPropertiesAsString) {
-    return result
+    return null
   }
 
   try {
-    result = JSON.parse(userPropertiesAsString)
+    return JSON.parse(userPropertiesAsString)
   } catch (error) {
-    // TODO: handle error?
+    return null
   }
-  return result
 }
 
 function getGroups(groups) {

--- a/tests/index.test.js
+++ b/tests/index.test.js
@@ -100,7 +100,7 @@ tap.test('Plain Custom Service', test => {
     assert.ok(/charset=utf-8/.test(response.headers['content-type']))
     assert.strictSame(JSON.parse(response.payload), {
       userId: null,
-      userProperties: {},
+      userProperties: null,
       userGroups: [],
       clientType: null,
       backoffice: false,

--- a/tests/index.test.js
+++ b/tests/index.test.js
@@ -22,6 +22,7 @@ const lc39 = require('@mia-platform/lc39')
 const fs = require('fs')
 const { promisify } = require('util')
 
+const USER_PROPERTIES_HEADER_KEY = 'miauserproperties'
 const USERID_HEADER_KEY = 'userid-header-key'
 const GROUPS_HEADER_KEY = 'groups-header-key'
 const CLIENTTYPE_HEADER_KEY = 'clienttype-header-key'
@@ -30,6 +31,7 @@ const MICROSERVICE_GATEWAY_SERVICE_NAME = 'microservice-gateway'
 
 const baseEnv = {
   USERID_HEADER_KEY,
+  USER_PROPERTIES_HEADER_KEY,
   GROUPS_HEADER_KEY,
   CLIENTTYPE_HEADER_KEY,
   BACKOFFICE_HEADER_KEY,
@@ -68,6 +70,7 @@ tap.test('Plain Custom Service', test => {
         [CLIENTTYPE_HEADER_KEY]: 'CMS',
         [GROUPS_HEADER_KEY]: 'group-name,group-to-greet',
         [USERID_HEADER_KEY]: 'Mark',
+        [USER_PROPERTIES_HEADER_KEY]: JSON.stringify({ prop1: 'value1', prop2: 'value2' }),
       },
     })
 
@@ -77,6 +80,7 @@ tap.test('Plain Custom Service', test => {
     assert.strictSame(JSON.parse(response.payload), {
       userId: 'Mark',
       userGroups: ['group-name', 'group-to-greet'],
+      userProperties: { prop1: 'value1', prop2: 'value2' },
       clientType: 'CMS',
       backoffice: false,
     })
@@ -96,6 +100,7 @@ tap.test('Plain Custom Service', test => {
     assert.ok(/charset=utf-8/.test(response.headers['content-type']))
     assert.strictSame(JSON.parse(response.payload), {
       userId: null,
+      userProperties: {},
       userGroups: [],
       clientType: null,
       backoffice: false,

--- a/tests/microserviceGateway.test.js
+++ b/tests/microserviceGateway.test.js
@@ -21,6 +21,7 @@ const nock = require('nock')
 const lc39 = require('@mia-platform/lc39')
 
 const USERID_HEADER_KEY = 'userid-header-key'
+const USER_PROPERTIES_HEADER_KEY = 'miauserproperties'
 const GROUPS_HEADER_KEY = 'groups-header-key'
 const CLIENTTYPE_HEADER_KEY = 'clienttype-header-key'
 const BACKOFFICE_HEADER_KEY = 'backoffice-header-key'
@@ -29,6 +30,7 @@ const ADDITIONAL_HEADERS_TO_PROXY = 'additionalheader1,additionalheader2'
 
 const baseEnv = {
   USERID_HEADER_KEY,
+  USER_PROPERTIES_HEADER_KEY,
   GROUPS_HEADER_KEY,
   CLIENTTYPE_HEADER_KEY,
   BACKOFFICE_HEADER_KEY,
@@ -54,6 +56,7 @@ tap.test('Call microservice gateway proxy', test => {
     const headers = {
       [CLIENTTYPE_HEADER_KEY]: 'CMS',
       [USERID_HEADER_KEY]: 'userid',
+      [USER_PROPERTIES_HEADER_KEY]: JSON.stringify({ prop1: 'value1' }),
       [GROUPS_HEADER_KEY]: 'group-to-greet,group',
       [BACKOFFICE_HEADER_KEY]: '',
     }
@@ -171,6 +174,7 @@ tap.test('Call microservice gateway proxy', test => {
     const headers = {
       [CLIENTTYPE_HEADER_KEY]: 'CMS',
       [USERID_HEADER_KEY]: 'userid',
+      [USER_PROPERTIES_HEADER_KEY]: JSON.stringify({ prop1: 'value1' }),
       [GROUPS_HEADER_KEY]: 'group-to-greet,group',
       [BACKOFFICE_HEADER_KEY]: '',
       additionalheader1: 'header1value',

--- a/tests/postDecorator.test.js
+++ b/tests/postDecorator.test.js
@@ -20,12 +20,14 @@ const tap = require('tap')
 const lc39 = require('@mia-platform/lc39')
 
 const USERID_HEADER_KEY = 'userid-header-key'
+const USER_PROPERTIES_HEADER_KEY = 'miauserproperties'
 const GROUPS_HEADER_KEY = 'groups-header-key'
 const CLIENTTYPE_HEADER_KEY = 'clienttype-header-key'
 const BACKOFFICE_HEADER_KEY = 'backoffice-header-key'
 const MICROSERVICE_GATEWAY_SERVICE_NAME = 'microservice-gateway'
 const baseEnv = {
   USERID_HEADER_KEY,
+  USER_PROPERTIES_HEADER_KEY,
   GROUPS_HEADER_KEY,
   CLIENTTYPE_HEADER_KEY,
   BACKOFFICE_HEADER_KEY,
@@ -205,6 +207,7 @@ tap.test('Test Post Decorator function', test => {
           headers: {
             [CLIENTTYPE_HEADER_KEY]: 'CMS',
             [USERID_HEADER_KEY]: 'userid',
+            [USER_PROPERTIES_HEADER_KEY]: JSON.stringify({ prop1: 'value1' }),
             [GROUPS_HEADER_KEY]: 'group-to-greet,group',
             [BACKOFFICE_HEADER_KEY]: '1',
             my: 'headers',

--- a/tests/preDecorator.test.js
+++ b/tests/preDecorator.test.js
@@ -20,12 +20,14 @@ const tap = require('tap')
 const lc39 = require('@mia-platform/lc39')
 
 const USERID_HEADER_KEY = 'userid-header-key'
+const USER_PROPERTIES_HEADER_KEY = 'miauserproperties'
 const GROUPS_HEADER_KEY = 'groups-header-key'
 const CLIENTTYPE_HEADER_KEY = 'clienttype-header-key'
 const BACKOFFICE_HEADER_KEY = 'backoffice-header-key'
 const MICROSERVICE_GATEWAY_SERVICE_NAME = 'microservice-gateway'
 const baseEnv = {
   USERID_HEADER_KEY,
+  USER_PROPERTIES_HEADER_KEY,
   GROUPS_HEADER_KEY,
   CLIENTTYPE_HEADER_KEY,
   BACKOFFICE_HEADER_KEY,
@@ -166,6 +168,7 @@ tap.test('preDecorator', test => {
         headers: {
           [CLIENTTYPE_HEADER_KEY]: 'CMS',
           [USERID_HEADER_KEY]: 'userid',
+          [USER_PROPERTIES_HEADER_KEY]: JSON.stringify({ prop1: 'value1' }),
           [GROUPS_HEADER_KEY]: 'group-to-greet,group',
           [BACKOFFICE_HEADER_KEY]: '1',
           my: 'headers',

--- a/tests/services/plain-custom-service.js
+++ b/tests/services/plain-custom-service.js
@@ -52,6 +52,7 @@ module.exports = customService(async function clientGroups(service) {
     reply.send({
       userId: request.getUserId(),
       userGroups: request.getGroups(),
+      userProperties: request.getUserProperties(),
       clientType: request.getClientType(),
       backoffice: request.isFromBackOffice(),
     })

--- a/tests/services/post-decorator.js
+++ b/tests/services/post-decorator.js
@@ -19,6 +19,7 @@
 const customService = require('../../index')()
 
 const USERID_HEADER_KEY = 'userid-header-key'
+const USER_PROPERTIES_HEADER_KEY = 'miauserproperties'
 const GROUPS_HEADER_KEY = 'groups-header-key'
 const CLIENTTYPE_HEADER_KEY = 'clienttype-header-key'
 const BACKOFFICE_HEADER_KEY = 'backoffice-header-key'
@@ -56,6 +57,7 @@ module.exports = customService(async function clientGroups(service) {
 
   function accessDataHandler(request) {
     this.assert.equal(request.getUserId(), 'userid')
+    this.assert.deepEqual(request.getUserProperties(), { prop1: 'value1' })
     this.assert.deepEqual(request.getGroups(), ['group-to-greet', 'group'])
     this.assert.equal(request.getClientType(), 'CMS')
     this.assert.equal(request.isFromBackOffice(), true)
@@ -68,6 +70,7 @@ module.exports = customService(async function clientGroups(service) {
       headers: {
         [CLIENTTYPE_HEADER_KEY]: 'CMS',
         [USERID_HEADER_KEY]: 'userid',
+        [USER_PROPERTIES_HEADER_KEY]: JSON.stringify({ prop1: 'value1' }),
         [GROUPS_HEADER_KEY]: 'group-to-greet,group',
         [BACKOFFICE_HEADER_KEY]: '1',
         my: 'headers',
@@ -77,6 +80,7 @@ module.exports = customService(async function clientGroups(service) {
     this.assert.deepEqual(request.getOriginalRequestHeaders(), {
       [CLIENTTYPE_HEADER_KEY]: 'CMS',
       [USERID_HEADER_KEY]: 'userid',
+      [USER_PROPERTIES_HEADER_KEY]: JSON.stringify({ prop1: 'value1' }),
       [GROUPS_HEADER_KEY]: 'group-to-greet,group',
       [BACKOFFICE_HEADER_KEY]: '1',
       my: 'headers',

--- a/tests/services/pre-decorator.js
+++ b/tests/services/pre-decorator.js
@@ -19,6 +19,7 @@
 const customService = require('../../index')()
 
 const USERID_HEADER_KEY = 'userid-header-key'
+const USER_PROPERTIES_HEADER_KEY = 'miauserproperties'
 const GROUPS_HEADER_KEY = 'groups-header-key'
 const CLIENTTYPE_HEADER_KEY = 'clienttype-header-key'
 const BACKOFFICE_HEADER_KEY = 'backoffice-header-key'
@@ -57,6 +58,7 @@ module.exports = customService(async function clientGroups(service) {
 
   function accessDataHandler(request) {
     this.assert.equal(request.getUserId(), 'userid')
+    this.assert.deepEqual(request.getUserProperties(), { prop1: 'value1' })
     this.assert.deepEqual(request.getGroups(), ['group-to-greet', 'group'])
     this.assert.equal(request.getClientType(), 'CMS')
     this.assert.equal(request.isFromBackOffice(), true)
@@ -69,6 +71,7 @@ module.exports = customService(async function clientGroups(service) {
       headers: {
         [CLIENTTYPE_HEADER_KEY]: 'CMS',
         [USERID_HEADER_KEY]: 'userid',
+        [USER_PROPERTIES_HEADER_KEY]: JSON.stringify({ prop1: 'value1' }),
         [GROUPS_HEADER_KEY]: 'group-to-greet,group',
         [BACKOFFICE_HEADER_KEY]: '1',
         my: 'headers',
@@ -78,6 +81,7 @@ module.exports = customService(async function clientGroups(service) {
     this.assert.deepEqual(request.getOriginalRequestHeaders(), {
       [CLIENTTYPE_HEADER_KEY]: 'CMS',
       [USERID_HEADER_KEY]: 'userid',
+      [USER_PROPERTIES_HEADER_KEY]: JSON.stringify({ prop1: 'value1' }),
       [GROUPS_HEADER_KEY]: 'group-to-greet,group',
       [BACKOFFICE_HEADER_KEY]: '1',
       my: 'headers',


### PR DESCRIPTION
fastify.Request decorated with `getUserProperties()` which always returns a Javascript Object (empty if anything). The Javascript Object is obtained by JSON parsing the field `fastify.Request.headers[USER_PROPERTIES_HEADER_KEY]`, where `USER_PROPERTIES_HEADER_KEY` can be set by the user for the custom-plugin (default value is `miauserproperties`)

#### Checklist

- [x] your branch will not cause merge conflict with `master`
- [x] run `npm test`
- [x] tests are included
- [x] the documentation is updated or intregrated accordingly with your changes
- [x] the code will follow the lint rules and style of the project
- [x] you are not committing extraneous files or sensible data
