### PR TITLE
added test to check usage of default 'miauserproperties'

### DIFF
--- a/tests/index.test.js
+++ b/tests/index.test.js
@@ -87,6 +87,35 @@ tap.test('Plain Custom Service', test => {
     assert.end()
   })
 
+  test.test('Access platform "miauserproperties" - when USER_PROPERTIES_HEADER_KEY NOT defined - uses default header key', async assert => {
+    const envarWithoutUserProperties = {
+      ...baseEnv,
+    }
+    delete envarWithoutUserProperties.USER_PROPERTIES_HEADER_KEY
+
+    const fastify = await setupFastify(envarWithoutUserProperties)
+
+    const response = await fastify.inject({
+      method: 'GET',
+      url: '/platform-values',
+      headers: {
+        'miauserproperties': JSON.stringify({ prop1: 'value1', prop2: 'value2' }),
+      },
+    })
+
+    assert.strictSame(response.statusCode, 200)
+    assert.ok(/application\/json/.test(response.headers['content-type']))
+    assert.ok(/charset=utf-8/.test(response.headers['content-type']))
+    assert.strictSame(JSON.parse(response.payload), {
+      userId: null,
+      userGroups: [],
+      userProperties: { prop1: 'value1', prop2: 'value2' },
+      clientType: null,
+      backoffice: false,
+    })
+    assert.end()
+  })
+
   test.test('Access platform values when not declared', async assert => {
     const fastify = await setupFastify(baseEnv)
     const response = await fastify.inject({


### PR DESCRIPTION
Added test to check the usage of default header key "miauserproperties" when envar `USER_PROPERTIES_HEADER_KEY` is not set for the microservice.
#### Checklist

- [x] your branch will not cause merge conflict with `master`
- [x] run `npm test`
- [x] tests are included
- [x] the documentation is updated or intregrated accordingly with your changes
- [x] the code will follow the lint rules and style of the project
- [x] you are not committing extraneous files or sensible data
