### PR TITLE
UPDATE(BMP-508-tris): updated lc39 dependency to 3.1.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## v2.0.2 - 2020-09-29
 
+## [Unrealeased]
+
+- [BMP-508](https://makeitapp.atlassian.net/browse/BMP-508): updated lc39 dependency to 3.1.3
+
 ### Added
 
   - [BMP-508](https://makeitapp.atlassian.net/browse/BMP-508): updated lc39 dependency to 3.1.2

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,11 +4,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## v2.0.2 - 2020-09-29
-
 ## [Unrealeased]
 
 - [BMP-508](https://makeitapp.atlassian.net/browse/BMP-508): updated lc39 dependency to 3.1.3
+
+## v2.0.2 - 2020-09-29
 
 ### Added
 

--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
     "version": "./scripts/update-version.sh ${npm_package_version} && git add CHANGELOG.md"
   },
   "dependencies": {
-    "@mia-platform/lc39": "^3.1.2",
+    "@mia-platform/lc39": "^3.1.3",
     "@types/node": "^13.9.1",
     "ajv": "^6.12.0",
     "fastify-env": "^1.0.1",


### PR DESCRIPTION
Updated lc39 dependency to 3.1.3, package lock has not been modified since it was already updated to 3.1.3.

[BMP-508](https://makeitapp.atlassian.net/browse/BMP-508)

#### Checklist

- [X] your branch will not cause merge conflict with `master`
- [x] run `npm test`
- [ ] tests are included
- [ ] the documentation is updated or intregrated accordingly with your changes
- [X] the code will follow the lint rules and style of the project
- [X] you are not committing extraneous files or sensible data
