### PR TITLE
Updated library to rely on Fastify v3 and latest lc39 version

### DIFF
--- a/.nvmrc
+++ b/.nvmrc
@@ -1,1 +1,1 @@
-lts/dubnium
+lts/fermium

--- a/index.d.ts
+++ b/index.d.ts
@@ -65,7 +65,9 @@ declare namespace customPlugin {
     USER_PROPERTIES_HEADER_KEY: string,
     GROUPS_HEADER_KEY: string,
     CLIENTTYPE_HEADER_KEY: string,
-    BACKOFFICE_HEADER_KEY: string
+    BACKOFFICE_HEADER_KEY: string,
+    MICROSERVICE_GATEWAY_SERVICE_NAME: string,
+    ADDITIONAL_HEADERS_TO_PROXY: string[]
   }
 
   //

--- a/index.d.ts
+++ b/index.d.ts
@@ -37,7 +37,7 @@ declare namespace customPlugin {
   type RawCustomPluginAdvancedConfig = Pick<fastify.RouteShorthandOptions,
     'schema' |
     'attachValidation' |
-    'schemaCompiler' |
+    'validatorCompiler' |
     'bodyLimit' |
     'logLevel' |
     'config' |
@@ -53,7 +53,7 @@ declare namespace customPlugin {
     getServiceProxy: (options?: InitServiceOptions) => Service,
   }
 
-  interface DecoratedRequest extends fastify.FastifyRequest<http.IncomingMessage> {
+  interface DecoratedRequest extends fastify.FastifyRequest {
     getUserId: () => string | null,
     getUserProperties: () => object | null,
     getGroups: () => string[],
@@ -71,8 +71,8 @@ declare namespace customPlugin {
   //
   // CUSTOM PLUGIN
   //
-  type Handler = (this: DecoratedFastify, request: DecoratedRequest, reply: fastify.FastifyReply<http.ServerResponse>) => void
-  type AsyncHandler = (this: DecoratedFastify, request: DecoratedRequest, reply: fastify.FastifyReply<http.ServerResponse>) => Promise<any>
+  type Handler = (this: DecoratedFastify, request: DecoratedRequest, reply: fastify.FastifyReply) => void
+  type AsyncHandler = (this: DecoratedFastify, request: DecoratedRequest, reply: fastify.FastifyReply) => Promise<any>
 
   //
   // SERVICE
@@ -123,7 +123,7 @@ declare namespace customPlugin {
   }
   interface AbortRequestAction { }
   type PreDecoratorAction = LeaveRequestUnchangedAction | ChangeRequestAction | AbortRequestAction;
-  type preDecoratorHandler = (this: DecoratedFastify, request: PreDecoratorDecoratedRequest, reply: fastify.FastifyReply<http.ServerResponse>) => Promise<PreDecoratorAction>;
+  type preDecoratorHandler = (this: DecoratedFastify, request: PreDecoratorDecoratedRequest, reply: fastify.FastifyReply) => Promise<PreDecoratorAction>;
 
   interface OriginalRequest {
     method: string,
@@ -165,7 +165,7 @@ declare namespace customPlugin {
   }
   interface AbortResponseAction { }
   type PostDecoratorAction = LeaveResponseUnchangedAction | ChangeResponseAction | AbortResponseAction;
-  type postDecoratorHandler = (this: DecoratedFastify, request: PostDecoratorDecoratedRequest, reply: fastify.FastifyReply<http.ServerResponse>) => Promise<PostDecoratorAction>;
+  type postDecoratorHandler = (this: DecoratedFastify, request: PostDecoratorDecoratedRequest, reply: fastify.FastifyReply) => Promise<PostDecoratorAction>;
 
   interface PostDecoratorDecoratedRequest extends DecoratedRequest {
     getOriginalRequest: () => OriginalRequest,

--- a/index.js
+++ b/index.js
@@ -163,7 +163,7 @@ async function decorateRequestAndFastifyInstance(fastify, { asyncInitFunction })
   const { config } = fastify
 
   const ajv = new Ajv({ coerceTypes: true, useDefaults: true })
-  fastify.setSchemaCompiler(schema => ajv.compile(schema))
+  fastify.setValidatorCompiler(({ schema }) => ajv.compile(schema))
 
   fastify.decorateRequest(USERID_HEADER_KEY, config[USERID_HEADER_KEY])
   fastify.decorateRequest(USER_PROPERTIES_HEADER_KEY, config[USER_PROPERTIES_HEADER_KEY])
@@ -171,7 +171,12 @@ async function decorateRequestAndFastifyInstance(fastify, { asyncInitFunction })
   fastify.decorateRequest(CLIENTTYPE_HEADER_KEY, config[CLIENTTYPE_HEADER_KEY])
   fastify.decorateRequest(BACKOFFICE_HEADER_KEY, config[BACKOFFICE_HEADER_KEY])
   fastify.decorateRequest(MICROSERVICE_GATEWAY_SERVICE_NAME, config[MICROSERVICE_GATEWAY_SERVICE_NAME])
-  fastify.decorateRequest(ADDITIONAL_HEADERS_TO_PROXY, config[ADDITIONAL_HEADERS_TO_PROXY].split(',').filter(header => header))
+  fastify.decorateRequest(ADDITIONAL_HEADERS_TO_PROXY, null)
+
+  // add mutable references later
+  fastify.addHook('onRequest', async(req) => {
+    req.ADDITIONAL_HEADERS_TO_PROXY = config[ADDITIONAL_HEADERS_TO_PROXY].split(',').filter(header => header)
+  })
 
   fastify.decorateRequest('getMiaHeaders', getMiaHeaders)
   fastify.decorateRequest('getOriginalRequestHeaders', getOriginalRequestHeaders)
@@ -188,8 +193,8 @@ async function decorateRequestAndFastifyInstance(fastify, { asyncInitFunction })
   fastify.decorate('getServiceProxy', getServiceBuilderFromService)
 
   fastify.register(fp(asyncInitFunction))
-  fastify.setErrorHandler(function errorHanlder(error, request, reply) {
-    if (reply.res.statusCode === 500 && !error.statusCode) {
+  fastify.setErrorHandler(function errorHandler(error, request, reply) {
+    if (reply.raw.statusCode === 500 && !error.statusCode) {
       request.log.error(error)
       reply.send(new Error('Something went wrong'))
     } else {

--- a/index.js
+++ b/index.js
@@ -171,11 +171,10 @@ async function decorateRequestAndFastifyInstance(fastify, { asyncInitFunction })
   fastify.decorateRequest(CLIENTTYPE_HEADER_KEY, config[CLIENTTYPE_HEADER_KEY])
   fastify.decorateRequest(BACKOFFICE_HEADER_KEY, config[BACKOFFICE_HEADER_KEY])
   fastify.decorateRequest(MICROSERVICE_GATEWAY_SERVICE_NAME, config[MICROSERVICE_GATEWAY_SERVICE_NAME])
-  fastify.decorateRequest(ADDITIONAL_HEADERS_TO_PROXY, null)
-
-  // add mutable references later
-  fastify.addHook('onRequest', async(req) => {
-    req.ADDITIONAL_HEADERS_TO_PROXY = config[ADDITIONAL_HEADERS_TO_PROXY].split(',').filter(header => header)
+  fastify.decorateRequest(ADDITIONAL_HEADERS_TO_PROXY, {
+    getter() {
+      return config[ADDITIONAL_HEADERS_TO_PROXY].split(',').filter(header => header)
+    },
   })
 
   fastify.decorateRequest('getMiaHeaders', getMiaHeaders)

--- a/index.js
+++ b/index.js
@@ -19,7 +19,10 @@
 const fastifyEnv = require('fastify-env')
 const fp = require('fastify-plugin')
 const fastifyFormbody = require('fastify-formbody')
+
 const Ajv = require('ajv')
+const addFormats = require('ajv-formats')
+
 const path = require('path')
 const { name, description, version } = require(path.join(process.cwd(), 'package.json'))
 
@@ -163,6 +166,7 @@ async function decorateRequestAndFastifyInstance(fastify, { asyncInitFunction })
   const { config } = fastify
 
   const ajv = new Ajv({ coerceTypes: true, useDefaults: true })
+  addFormats(ajv)
   fastify.setValidatorCompiler(({ schema }) => ajv.compile(schema))
 
   fastify.decorateRequest(USERID_HEADER_KEY, config[USERID_HEADER_KEY])

--- a/package.json
+++ b/package.json
@@ -41,25 +41,25 @@
     "version": "./scripts/update-version.sh ${npm_package_version} && git add CHANGELOG.md"
   },
   "dependencies": {
-    "@mia-platform/lc39": "^3.3.0",
-    "@types/node": "^13.9.1",
+    "@mia-platform/lc39": "^4.0.0-rc.0",
+    "@types/node": "^14.14.14",
     "ajv": "^6.12.6",
-    "fastify-env": "^1.0.1",
-    "fastify-formbody": "^3.1.0",
-    "fastify-plugin": "^1.6.1",
+    "fastify-env": "^2.1.0",
+    "fastify-formbody": "^5.0.0",
+    "fastify-plugin": "^3.0.0",
     "http-errors": "^1.8.0",
     "simple-get": "^4.0.0"
   },
   "devDependencies": {
     "@mia-platform/eslint-config-mia": "^3.0.0",
-    "eslint": "^7.6.0",
-    "fastify-routes": "^2.0.3",
+    "eslint": "^7.16.0",
+    "fastify-routes": "^3.0.1",
     "hpagent": "^0.1.1",
     "nock": "^13.0.3",
     "pre-commit": "^1.2.2",
     "proxy": "^1.0.2",
     "tap": "^14.10.6",
-    "typescript": "^3.8.3"
+    "typescript": "^4.1.3"
   },
   "engines": {
     "node": ">=10"

--- a/package.json
+++ b/package.json
@@ -42,8 +42,9 @@
   },
   "dependencies": {
     "@mia-platform/lc39": "^4.0.0-rc.0",
-    "@types/node": "^14.14.14",
-    "ajv": "^6.12.6",
+    "@types/node": "^14.14.37",
+    "ajv": "^8.0.1",
+    "ajv-formats": "^2.0.1",
     "fastify-env": "^2.1.0",
     "fastify-formbody": "^5.0.0",
     "fastify-plugin": "^3.0.0",
@@ -52,14 +53,14 @@
   },
   "devDependencies": {
     "@mia-platform/eslint-config-mia": "^3.0.0",
-    "eslint": "^7.16.0",
+    "eslint": "^7.23.0",
     "fastify-routes": "^3.0.1",
     "hpagent": "^0.1.1",
-    "nock": "^13.0.3",
+    "nock": "^13.0.11",
     "pre-commit": "^1.2.2",
     "proxy": "^1.0.2",
-    "tap": "^14.10.6",
-    "typescript": "^4.1.3"
+    "tap": "^14.11.0",
+    "typescript": "^4.2.3"
   },
   "engines": {
     "node": ">=10"

--- a/tests/services/plain-custom-service.js
+++ b/tests/services/plain-custom-service.js
@@ -31,13 +31,13 @@ const schema = {
   },
 }
 
-function customParser(req, done) {
+function customParser(req, payload, done) {
   let data = ''
-  req.on('data', chunk => {
+  payload.on('data', chunk => {
     data += chunk
   })
 
-  req.on('end', () => {
+  payload.on('end', () => {
     done(null, data)
   })
 }

--- a/tests/types/index.ts
+++ b/tests/types/index.ts
@@ -74,9 +74,9 @@ async function invokeSomeApis(service: cpl.Service) {
   console.log(response.payload)
 
   const responseAsBuffer = await service.get('/path') as cpl.BufferServiceResponse
-  console.log(response.statusCode)
-  console.log(response.headers)
-  console.log(response.payload)
+  console.log(responseAsBuffer.statusCode)
+  console.log(responseAsBuffer.headers)
+  console.log(responseAsBuffer.payload)
 
   const responseAsStream = await service.get('/path', {}, { returnAs: 'STREAM' })  as cpl.StreamedServiceResponse
   let d: string = ''
@@ -228,13 +228,13 @@ a(async function (service) {
 async function invokeProxies() {
   const directServiceProxy = getDirectServiceProxy('service_name')
   const directServiceProxyWithOpetions = getDirectServiceProxy('service_name', { port: 3000 })
-  
+
   await directServiceProxy.get('/path')
   await directServiceProxyWithOpetions.get('/path')
 
   const serviceProxy = getServiceProxy('microservice-gateway')
   const serviceProxyWithOpetions = getServiceProxy('microservice-gateway', { port: 3000 })
-  
+
   await serviceProxy.get('/path')
   await serviceProxyWithOpetions.get('/path')
 }


### PR DESCRIPTION
<!-- Hi, and thank you for your time dedicated to this pull request! Please provide a description
of the work you have done and be sure to link to the relative open issue if is present.

Be aware that all the work you have done should include also the relative tests to assure the
correct behavior and avoid possible regressions in the future.
-->

Hi, I updated the custom-plugin-lib to support Fastify v3 and the latest [lc39](https://github.com/mia-platform/lc39) release candidate version.

In order to carry out this task I followed the [migration guide](https://github.com/fastify/fastify/blob/master/docs/Migration-Guide-V3.md) of Fastify to correct breaking changes and deprecations. The library has been tested using existing tests to check that no regression has been introduced in the update process.

#### Changes

- bump `@mia-platform/lc39` version from 3.3.0 to 4.0.0-rc.0
- bump `@types/node` version from 13.9.1 to 14.14.37
- bump `fastify-env` version from 1.0.1 to 2.1.0
- bump `fastify-formbody` version from 3.1.0 to 5.0.0
- bump `fastify-plugin` version from 1.6.1 to 3.0.0
- bump `eslint` version from 7.6.0 to 7.16.0
- bump `fastify-routes` version from 2.0.3 to 3.0.1
- bump `typescript` version from 3.8.3 to 4.2.3
- bump `ajv` version from 6.12.6 to 8.0.1
- exchanged **setschemaCompiler** with the new **setValidatorCompiler** function
- updated typescript types since Fastify v3 uses its own types (FastifyRequest and FastifyReply) rather than underlying http lib types
- addressed deprecation of attaching Object references to Fastify Request (prevent memory leaks as explained in the migration guide)

    > In this example the reference of the object is shared with all the requests: any mutation will impact all requests, potentially creating security vulnerabilities or memory leaks. To achieve proper encapsulation across requests configure a new value for each incoming request in the 'onRequest' hook (https://www.fastify.io/docs/latest/Decorators/)
- converted error handler to use the **raw** reply object
- updated the **content type parser** function to match v3 definitions
- fixed typos and unused variables

#### Notes

Before updating a service that adopts the custom-plugin-lib it might be advised to check that its JSON-schema is compatible with the Fastify latest version (`$ref` support). For more details see [here](https://github.com/fastify/fastify/blob/master/docs/Migration-Guide-V3.md#changed-schema-substitution-2023)

#### Checklist

- [x] your branch will not cause merge conflict with `master`
- [x] run `npm test`
- [x] tests are included
- [ ] the documentation is updated or integrated accordingly with your changes
- [x] the code will follow the lint rules and style of the project
- [x] you are not committing extraneous files or sensible data

#### Notify to
@davidebianchi