### PR TITLE
Fixed PostDecoratorDecoratedRequest typings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## Unreleased
+
+### Fixes
+
+- Fixed PostDecoratorDecoratedRequest typing
+
 ## v4.2.0 - 2021-10-15
 
 ### Added

--- a/index.d.ts
+++ b/index.d.ts
@@ -203,7 +203,7 @@ declare namespace customPlugin {
 
     getMiaHeaders: () => NodeJS.Dict<string>,
 
-    changeOriginalRequest: () => ChangeResponseAction,
+    changeOriginalResponse: () => ChangeResponseAction,
     leaveOriginalResponseUnmodified: () => LeaveResponseUnchangedAction,
     abortChain: (statusCode: number, finalBody: any, headers?: http.IncomingHttpHeaders) => AbortResponseAction
   }

--- a/tests/types/index.ts
+++ b/tests/types/index.ts
@@ -217,7 +217,7 @@ a(async function (service) {
 
     return request.leaveOriginalResponseUnmodified()
   }).addPostDecorator('/decorators/my-post2', async function myHandlerPostDecorator(request, reply) {
-    return request.changeOriginalRequest()
+    return request.changeOriginalResponse()
       .setBody({ new: 'body' })
       .setStatusCode(201)
       .setHeaders({ rewrite: 'the headers completely' })


### PR DESCRIPTION
Fixed PostDecoratorDecoratedRequest typings by changing property `changeOriginalRequest` in `changeOriginalResponse`.

#### Checklist

- [x] your branch will not cause merge conflict with `master`
- [x] run `npm test`
- [x] tests are included
- [x] the documentation is updated or integrated accordingly with your changes
- [x] the code will follow the lint rules and style of the project
- [x] you are not committing extraneous files or sensible data
