### PR TITLE
fix: options provisioning

### DIFF
--- a/index.js
+++ b/index.js
@@ -132,7 +132,7 @@ function getDirectlyServiceBuilderFromRequest(serviceNameOrURL, baseOptions = {}
     return getDirectServiceProxyFromUrlString(
       serviceNameOrURL,
       serviceHeaders,
-      baseOptions
+      options
     )
   } catch (error) {
     return serviceBuilder(serviceNameOrURL, serviceHeaders, options)


### PR DESCRIPTION
<!-- Hi, and thank you for your time dedicated to this pull request! Please provide a description
of the work you have done and be sure to link to the relative open issue if is present.

Be aware that all the work you have done should include also the relative tests to assure the
correct behavior and avoid possible regressions in the future.
-->

I noticed that the builder for the direct service proxy API is provided with the `baseOption` parameter while the correct parameter should be `options`. Diving a bit into the past merge requests I found this one where the provided param was `options`.

I believe there is a bug hidden here even though current tests are still passing.

#### Checklist

- [X] your branch will not cause merge conflict with `master`
- [X] run `npm test`
- [ ] tests are included
- [ ] the documentation is updated or integrated accordingly with your changes
- [X] the code will follow the lint rules and style of the project
- [X] you are not committing extraneous files or sensible data
