### PR TITLE
Decorate httpClient response with duration property

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## v5.1.3 - 2022-10-07
+
+### Fixed
+
+- http client base options
+
 ## v5.1.2 - 2022-09-23
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## Unreleased
+## v5.1.2 - 2022-09-23
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+### Unreleased
+
+### Added
+
+- add property `duration` to the httpClient response
+
 ## v5.1.3 - 2022-10-07
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## Unreleased
+
+### Fixed
+
+- http client base options
+
 ## v5.1.1 - 2022-07-21
 
 ### Fixed

--- a/docs/http_client.md
+++ b/docs/http_client.md
@@ -55,6 +55,7 @@ All methods return a *Promise object*. You can access to:
 * **Status code** of the response trough the `statusCode` property
 * **Body** of the response trough the `payload` property
 * **Headers** of the response trough the `headers` property
+* **Duration** of the http call trough the `duration` property
 
 If service responds with status code not valid (it is possible to modify this using the `validateStatus` ), the error object contains:
 
@@ -62,6 +63,7 @@ If service responds with status code not valid (it is possible to modify this us
 * **Status code** of the response trough the `statusCode` property
 * **Body** of the response trough the `payload` property
 * **Headers** of the response trough the `headers` property
+* **Duration** of the http call trough the `duration` property
 
 If error is not an http error, it is throw the error message and the error code.
 

--- a/index.d.ts
+++ b/index.d.ts
@@ -16,6 +16,7 @@
 
 import * as fastify from 'fastify'
 import * as http from 'http'
+import * as https from 'https'
 
 import {FormatName} from 'ajv-formats'
 
@@ -128,6 +129,7 @@ declare namespace customPlugin {
     cert?: string,
     key?: string,
     ca?: string,
+    httpsAgent?: https.Agent,
     logger?: fastify.FastifyLoggerInstance,
     isMiaHeaderInjected?: boolean
   }

--- a/index.d.ts
+++ b/index.d.ts
@@ -128,7 +128,8 @@ declare namespace customPlugin {
     cert?: string,
     key?: string,
     ca?: string,
-    logger?: fastify.FastifyLoggerInstance
+    logger?: fastify.FastifyLoggerInstance,
+    isMiaHeaderInjected?: boolean
   }
   interface BaseHttpClientResponse {
     headers: http.IncomingHttpHeaders
@@ -156,7 +157,6 @@ declare namespace customPlugin {
   interface HttpClientOptions extends HttpClientBaseOptions {
     returnAs?: 'STREAM' | 'JSON' | 'BUFFER';
     validateStatus?: (statusCode: number) => boolean;
-    isMiaHeaderInjected?: boolean;
     errorMessageKey?: string;
     proxy?: HttpClientProxy;
     query?: Record<string, string>;

--- a/lib/httpClient.js
+++ b/lib/httpClient.js
@@ -32,6 +32,7 @@ class HttpClient {
       baseURL: baseUrl,
       timeout: baseOptions.timeout,
     })
+    decorateResponseWithDuration(this.axios)
   }
 
   async get(path, options = {}) {
@@ -106,6 +107,7 @@ class HttpClient {
         statusCode: response.status,
         headers: response.headers,
         payload: response.data,
+        duration: response.duration,
       }
       logger.trace({ url, ...responseBody }, 'response info')
       return responseBody
@@ -116,6 +118,7 @@ class HttpClient {
         responseError.headers = error.response.headers
         responseError.statusCode = error.response.status
         responseError.payload = error.response.data
+        responseError.duration = error.duration
         // eslint-disable-next-line id-blacklist
         logger.error({ statusCode: error.response.status, message: errorMessage }, 'response error')
         throw responseError
@@ -212,6 +215,29 @@ function getHeaders(options, miaHeaders, baseOptions, payload) {
     ...baseOptions.headers || {},
     ...options.headers || {},
   }
+}
+
+function decorateResponseWithDuration(axiosInstance) {
+  axiosInstance.interceptors.response.use(
+    (response) => {
+      response.config.metadata.endTime = new Date()
+      response.duration = response.config.metadata.endTime - response.config.metadata.startTime
+      return response
+    },
+    (error) => {
+      error.config.metadata.endTime = new Date()
+      error.duration = error.config.metadata.endTime - error.config.metadata.startTime
+      return Promise.reject(error)
+    }
+  )
+
+  axiosInstance.interceptors.request.use(
+    (config) => {
+      config.metadata = { startTime: new Date() }
+      return config
+    }, (error) => {
+      return Promise.reject(error)
+    })
 }
 
 module.exports = HttpClient

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mia-platform/custom-plugin-lib",
-  "version": "5.1.2",
+  "version": "5.1.3",
   "description": "Library that allows you to define Mia-Platform custom plugins easily",
   "keywords": [
     "mia-platform",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mia-platform/custom-plugin-lib",
-  "version": "5.1.1",
+  "version": "5.1.2",
   "description": "Library that allows you to define Mia-Platform custom plugins easily",
   "keywords": [
     "mia-platform",

--- a/tests/httpClient.test.js
+++ b/tests/httpClient.test.js
@@ -323,7 +323,7 @@ tap.test('httpClient', test => {
       assert.end()
     })
 
-    innerTest.test('on 500 response includes duration property', async assert => {
+    innerTest.test('on not allowed statusCode error includes duration property', async assert => {
       const responseDelay = 50
       const myServiceNameScope = nock(MY_AWESOME_SERVICE_PROXY_HTTP_URL)
         .replyContentLength()


### PR DESCRIPTION
The httpClient response is decorated with a new property `duration` indicating the time passed before the call was resolved.
[relative issue](https://github.com/mia-platform/custom-plugin-lib/issues/275)

#### Checklist

- [x] your branch will not cause merge conflict with `master`
- [x] run `npm test`
- [x] tests are included
- [x] the documentation is updated or integrated accordingly with your changes
- [x] the code will follow the lint rules and style of the project
- [x] you are not committing extraneous files or sensible data
