### PR TITLE
Feature/http call duration metrics

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+### Unreleased
+
+### Added
+
+- add property `duration` to the httpClient response
+
 ## v5.1.1 - 2022-07-21
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- add optional metrics on request duration. The metrics collection is enabled by mean of the variable `ENABLE_HTTP_CLIENT_METRICS` (default: false)
+
+### Added
+
 - add property `duration` to the httpClient response
 
 ## v5.1.1 - 2022-07-21

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - add optional metrics on request duration. The metrics collection is enabled by mean of the variable `ENABLE_HTTP_CLIENT_METRICS` (default: false)
+
 ## v5.1.5 - 2022-11-24
 
 ### Fixed

--- a/docs/http_client.md
+++ b/docs/http_client.md
@@ -55,6 +55,7 @@ All methods return a *Promise object*. You can access to:
 * **Status code** of the response trough the `statusCode` property
 * **Body** of the response trough the `payload` property
 * **Headers** of the response trough the `headers` property
+* **Duration** of the http call trough the `duration` property
 
 If service responds with status code not valid (it is possible to modify this using the `validateStatus` ), the error object contains:
 
@@ -62,6 +63,7 @@ If service responds with status code not valid (it is possible to modify this us
 * **Status code** of the response trough the `statusCode` property
 * **Body** of the response trough the `payload` property
 * **Headers** of the response trough the `headers` property
+* **Duration** of the http call trough the `duration` property
 
 If error is not an http error, it is throw the error message and the error code.
 

--- a/index.d.ts
+++ b/index.d.ts
@@ -122,6 +122,10 @@ declare namespace customPlugin {
   //
   // HTTP CLIENT
   //
+  type HttpClientMetrics = {
+    disabled: Boolean
+    urlLabel: String
+  }
   interface HttpClientBaseOptions {
     headers?: http.IncomingHttpHeaders,
     timeout?: number,
@@ -133,6 +137,7 @@ declare namespace customPlugin {
   interface BaseHttpClientResponse {
     headers: http.IncomingHttpHeaders
     statusCode: number
+    duration: number
   }
   interface StreamResponse extends BaseHttpClientResponse {
     payload: NodeJS.ReadableStream
@@ -160,6 +165,7 @@ declare namespace customPlugin {
     errorMessageKey?: string;
     proxy?: HttpClientProxy;
     query?: Record<string, string>;
+    metrics?: HttpClientMetrics;
   }
 
   type RequestBody = any | Buffer | ReadableStream

--- a/index.d.ts
+++ b/index.d.ts
@@ -123,8 +123,8 @@ declare namespace customPlugin {
   // HTTP CLIENT
   //
   type HttpClientMetrics = {
-    disabled: Boolean
-    urlLabel: String
+    disabled: boolean
+    urlLabel: string
   }
   interface HttpClientBaseOptions {
     headers?: http.IncomingHttpHeaders,
@@ -132,7 +132,8 @@ declare namespace customPlugin {
     cert?: string,
     key?: string,
     ca?: string,
-    logger?: fastify.FastifyLoggerInstance
+    logger?: fastify.FastifyLoggerInstance,
+    disableMetrics?: boolean
   }
   interface BaseHttpClientResponse {
     headers: http.IncomingHttpHeaders

--- a/index.js
+++ b/index.js
@@ -38,6 +38,7 @@ const CLIENTTYPE_HEADER_KEY = 'CLIENTTYPE_HEADER_KEY'
 const BACKOFFICE_HEADER_KEY = 'BACKOFFICE_HEADER_KEY'
 const MICROSERVICE_GATEWAY_SERVICE_NAME = 'MICROSERVICE_GATEWAY_SERVICE_NAME'
 const ADDITIONAL_HEADERS_TO_PROXY = 'ADDITIONAL_HEADERS_TO_PROXY'
+const ENABLE_HTTP_CLIENT_METRICS = 'ENABLE_HTTP_CLIENT_METRICS'
 
 const baseSchema = {
   type: 'object',
@@ -84,6 +85,11 @@ const baseSchema = {
       type: 'string',
       default: '',
       description: 'comma separated list of additional headers to proxy',
+    },
+    [ENABLE_HTTP_CLIENT_METRICS]: {
+      type: 'boolean',
+      default: false,
+      description: 'flag to enable the httpClient metrics',
     },
   },
 }
@@ -199,11 +205,11 @@ function getHttpClientFromRequest(url, baseOptions = {}) {
   const extraHeaders = getCustomHeaders(extraHeadersKeys, requestHeaders)
   const options = getBaseOptionsDecorated(this[ADDITIONAL_HEADERS_TO_PROXY], baseOptions, requestHeaders)
   const serviceHeaders = { ...this.getMiaHeaders(), ...extraHeaders }
-  return new HttpClient(url, serviceHeaders, options)
+  return new HttpClient(url, serviceHeaders, options, this.httpClientMetrics)
 }
 
 function getHttpClient(url, baseOptions = {}) {
-  return new HttpClient(url, {}, baseOptions)
+  return new HttpClient(url, {}, baseOptions, this.httpClientMetrics)
 }
 
 function getHeadersToProxy({ isMiaHeaderInjected = true } = {}) {
@@ -221,6 +227,7 @@ function getHeadersToProxy({ isMiaHeaderInjected = true } = {}) {
 
 function decorateFastify(fastify) {
   const { config } = fastify
+  const httpClientMetrics = config[ENABLE_HTTP_CLIENT_METRICS] ? getHttpClientMetrics(fastify) : {}
 
   fastify.decorateRequest(USERID_HEADER_KEY, config[USERID_HEADER_KEY])
   fastify.decorateRequest(USER_PROPERTIES_HEADER_KEY, config[USER_PROPERTIES_HEADER_KEY])
@@ -241,6 +248,7 @@ function decorateFastify(fastify) {
   fastify.decorateRequest('getDirectServiceProxy', getDirectlyServiceBuilderFromRequest)
   fastify.decorateRequest('getServiceProxy', getServiceBuilderFromRequest)
   fastify.decorateRequest('getHttpClient', getHttpClientFromRequest)
+  fastify.decorateRequest('httpClientMetrics', httpClientMetrics)
 
   fastify.decorate(MICROSERVICE_GATEWAY_SERVICE_NAME, config[MICROSERVICE_GATEWAY_SERVICE_NAME])
   fastify.decorate('addRawCustomPlugin', addRawCustomPlugin)
@@ -250,6 +258,7 @@ function decorateFastify(fastify) {
   fastify.decorate('getDirectServiceProxy', getDirectlyServiceBuilderFromService)
   fastify.decorate('getServiceProxy', getServiceBuilderFromService)
   fastify.decorate('getHttpClient', getHttpClient)
+  fastify.decorate('httpClientMetrics', httpClientMetrics)
 }
 
 async function decorateRequestAndFastifyInstance(fastify, { asyncInitFunction, serviceOptions = {} }) {
@@ -310,6 +319,18 @@ function initCustomServiceEnvironment(envSchema = defaultSchema) {
       produces: ['application/json'],
     }
     return index
+  }
+}
+
+function getHttpClientMetrics(fastify) {
+  if (fastify.metrics?.client) {
+    const requestDuration = new fastify.metrics.client.Histogram({
+      name: 'http_request_duration_milliseconds',
+      help: 'request duration histogram',
+      labelNames: ['baseUrl', 'url', 'method', 'statusCode'],
+      buckets: [5, 10, 50, 100, 500, 1000, 5000, 10000],
+    })
+    return { requestDuration }
   }
 }
 

--- a/lib/httpClient.js
+++ b/lib/httpClient.js
@@ -1,4 +1,3 @@
-/* eslint-disable max-statements */
 /*
  * Copyright 2022 Mia srl
  *
@@ -84,6 +83,7 @@ class HttpClient {
     }
   }
 
+  // eslint-disable-next-line max-statements
   async makeCall(url, payload, options) {
     const logger = this.getLogger(options)
     const headers = getHeaders(options, this.requestHeadersToProxy, this.baseOptions, payload)
@@ -132,7 +132,6 @@ class HttpClient {
         responseError.statusCode = error.response.status
         responseError.payload = error.response.data
         responseError.duration = error.duration
-        // eslint-disable-next-line id-blacklist
         logger.error({ statusCode: error.response.status, message: errorMessage }, 'response error')
         if (metricsOptions.enabled) {
           this.metrics.requestDuration.observe({

--- a/lib/httpClient.js
+++ b/lib/httpClient.js
@@ -26,7 +26,7 @@ class HttpClient {
     this.baseURL = baseUrl
     this.requestHeadersToProxy = requestHeadersToProxy
     this.baseOptions = baseOptions
-    this.metrics = metrics
+    this.metrics = baseOptions.disableMetrics ? {} : metrics
 
     const httpsAgent = getHttpsAgent(baseOptions)
     this.axios = axios.create({

--- a/lib/httpClient.js
+++ b/lib/httpClient.js
@@ -1,3 +1,4 @@
+/* eslint-disable max-statements */
 /*
  * Copyright 2022 Mia srl
  *
@@ -21,10 +22,11 @@ const httpsClient = require('https')
 const Pino = require('pino')
 
 class HttpClient {
-  constructor(baseUrl, requestHeadersToProxy, baseOptions = {}) {
+  constructor(baseUrl, requestHeadersToProxy, baseOptions = {}, metrics = {}) {
     this.baseURL = baseUrl
     this.requestHeadersToProxy = requestHeadersToProxy
     this.baseOptions = baseOptions
+    this.metrics = metrics
 
     const httpsAgent = getHttpsAgent(baseOptions)
     this.axios = axios.create({
@@ -87,6 +89,7 @@ class HttpClient {
     const headers = getHeaders(options, this.requestHeadersToProxy, this.baseOptions, payload)
     const httpsAgent = getHttpsAgent(options)
     const errorMessageKey = getErrorMessageKey(options, this.baseOptions)
+    const metricsOptions = getMetricsOptions(options.metrics, url, this.metrics)
     try {
       const validateStatus = getValidateStatus(options)
       logger.trace({ baseURL: this.baseURL, url, headers, payload }, 'make call')
@@ -110,6 +113,16 @@ class HttpClient {
         duration: response.duration,
       }
       logger.trace({ url, ...responseBody }, 'response info')
+      if (metricsOptions.enabled) {
+        this.metrics.requestDuration.observe({
+          method: options.method,
+          url: metricsOptions.urlLabel,
+          baseUrl: this.baseURL,
+          statusCode: response.status,
+        },
+        response.duration,
+        )
+      }
       return responseBody
     } catch (error) {
       if (error.response) {
@@ -121,6 +134,16 @@ class HttpClient {
         responseError.duration = error.duration
         // eslint-disable-next-line id-blacklist
         logger.error({ statusCode: error.response.status, message: errorMessage }, 'response error')
+        if (metricsOptions.enabled) {
+          this.metrics.requestDuration.observe({
+            method: options.method,
+            url: metricsOptions.urlLabel,
+            baseUrl: this.baseURL,
+            statusCode: error.response.status,
+          },
+          error.duration,
+          )
+        }
         throw responseError
       }
       const errToReturn = new Error(error.message)
@@ -214,6 +237,13 @@ function getHeaders(options, miaHeaders, baseOptions, payload) {
     ...isMiaHeaderInjected ? miaHeaders : {},
     ...baseOptions.headers || {},
     ...options.headers || {},
+  }
+}
+
+function getMetricsOptions(metricsOptions = {}, url, metrics) {
+  return {
+    enabled: Boolean(metrics.requestDuration && metricsOptions.disabled !== true),
+    urlLabel: metricsOptions.urlLabel ?? url,
   }
 }
 

--- a/lib/httpClient.js
+++ b/lib/httpClient.js
@@ -32,6 +32,7 @@ class HttpClient {
       baseURL: baseUrl,
       timeout: baseOptions.timeout,
     })
+    decorateResponseWithDuration(this.axios)
   }
 
   async get(path, options = {}) {
@@ -106,6 +107,7 @@ class HttpClient {
         statusCode: response.status,
         headers: response.headers,
         payload: response.data,
+        duration: response.duration,
       }
       logger.trace({ url, ...responseBody }, 'response info')
       return responseBody
@@ -116,6 +118,7 @@ class HttpClient {
         responseError.headers = error.response.headers
         responseError.statusCode = error.response.status
         responseError.payload = error.response.data
+        responseError.duration = error.duration
         // eslint-disable-next-line id-blacklist
         logger.error({ statusCode: error.response.status, message: errorMessage }, 'response error')
         throw responseError
@@ -212,6 +215,29 @@ function getHeaders(options, miaHeaders, baseOptions, payload) {
     ...baseOptions.headers || {},
     ...options.headers || {},
   }
+}
+
+function decorateResponseWithDuration(axiosInstance) {
+  axiosInstance.interceptors.response.use(
+    (response) => {
+      response.config.metadata.endTime = new Date()
+      response.duration = response.config.metadata.endTime - response.config.metadata.startTime
+      return response
+    },
+    (error) => {
+      error.config.metadata.endTime = new Date()
+      error.duration = error.config.metadata.endTime - error.config.metadata.startTime
+      return Promise.reject(error)
+    }
+  )
+
+  axiosInstance.interceptors.request.use(
+    (config) => {
+      config.metadata = { startTime: new Date() }
+      return config
+    }, (error) => {
+      return Promise.reject(error)
+    })
 }
 
 module.exports = HttpClient

--- a/tests/getHttpClient.test.js
+++ b/tests/getHttpClient.test.js
@@ -10,6 +10,14 @@ const MY_AWESOME_SERVICE_PROXY_HTTPS_URL = 'https://my-awesome-service'
 const MY_AWESOME_SERVICE_PROXY_HTTP_URL_CUSTOM_PORT = 'http://my-awesome-service:3000'
 const MY_AWESOME_SERVICE_PROXY_HTTPS_URL_CUSTOM_PORT = 'https://my-awesome-service:3001'
 
+const fastifyMock = {
+  httpClientMetrics: {
+    requestDuration: {
+      observe: () => { /* no-op*/ },
+    },
+  },
+}
+
 tap.test('getHttpClient available for testing - complete url passed', async t => {
   nock.disableNetConnect()
   t.teardown(() => {
@@ -17,7 +25,7 @@ tap.test('getHttpClient available for testing - complete url passed', async t =>
   })
 
   const RETURN_MESSAGE = 'OK'
-  const customProxy = getHttpClient(MY_AWESOME_SERVICE_PROXY_HTTP_URL)
+  const customProxy = getHttpClient.call(fastifyMock, MY_AWESOME_SERVICE_PROXY_HTTP_URL)
   const awesomeHttpServiceScope = nock(`${MY_AWESOME_SERVICE_PROXY_HTTP_URL}:80`)
     .get('/test-endpoint')
     .reply(200, {
@@ -38,7 +46,7 @@ tap.test('getHttpClient available for testing - timeout passed', async t => {
   })
 
   const RETURN_MESSAGE = 'OK'
-  const customProxy = getHttpClient(MY_AWESOME_SERVICE_PROXY_HTTP_URL, {
+  const customProxy = getHttpClient.call(fastifyMock, MY_AWESOME_SERVICE_PROXY_HTTP_URL, {
     timeout: 100,
   })
   const awesomeHttpServiceScope = nock(`${MY_AWESOME_SERVICE_PROXY_HTTP_URL}:80`)
@@ -65,7 +73,7 @@ tap.test('getHttpClient available for testing - https url', async t => {
   })
 
   const RETURN_MESSAGE = 'OK'
-  const customProxy = getHttpClient(MY_AWESOME_SERVICE_PROXY_HTTPS_URL)
+  const customProxy = getHttpClient.call(fastifyMock, MY_AWESOME_SERVICE_PROXY_HTTPS_URL)
   const awesomeHttpsServiceScope = nock(`${MY_AWESOME_SERVICE_PROXY_HTTPS_URL}:443`)
     .get('/test-endpoint')
     .reply(200, {
@@ -86,7 +94,7 @@ tap.test('getHttpClient available for testing - custom port 3000 - custom header
   })
 
   const RETURN_MESSAGE = 'OK'
-  const customProxy = getHttpClient(MY_AWESOME_SERVICE_PROXY_HTTP_URL_CUSTOM_PORT,
+  const customProxy = getHttpClient.call(fastifyMock, MY_AWESOME_SERVICE_PROXY_HTTP_URL_CUSTOM_PORT,
     {
       headers: {
         'test-header': 'test header works',
@@ -113,7 +121,7 @@ tap.test('getHttpClient available for testing - https url - custom port 3001', a
   })
 
   const RETURN_MESSAGE = 'OK'
-  const customProxy = getHttpClient(MY_AWESOME_SERVICE_PROXY_HTTPS_URL_CUSTOM_PORT)
+  const customProxy = getHttpClient.call(fastifyMock, MY_AWESOME_SERVICE_PROXY_HTTPS_URL_CUSTOM_PORT)
   const awesomeHttpsServiceScope = nock(`${MY_AWESOME_SERVICE_PROXY_HTTPS_URL}:3001`)
     .get('/test-endpoint')
     .reply(200, {
@@ -130,7 +138,7 @@ tap.test('getHttpClient available for testing - https url - custom port 3001', a
 tap.test('getHttpClient throws on invalid url', async t => {
   const invalidUrl = 'httpnot-a-complete-url'
   try {
-    getHttpClient(invalidUrl)
+    getHttpClient.call(fastifyMock, invalidUrl)
   } catch (error) {
     t.notOk(true, 'The function should not throw anymore if the url is not a valid one, bet return the standard proxy')
   }

--- a/tests/httpClient.test.js
+++ b/tests/httpClient.test.js
@@ -1354,6 +1354,23 @@ tap.test('httpClient', test => {
       assert.end()
     })
 
+    innerTest.test('metrics are NOT collected if disabled on proxy level', async assert => {
+      observedMetrics = null
+      const expectedObservedMetrics = null
+      const myServiceNameScope = nock(MY_AWESOME_SERVICE_PROXY_HTTP_URL)
+        .get('/foo')
+        .delay(delay)
+        .reply(200, { the: 'response' })
+
+      const service = new HttpClient(MY_AWESOME_SERVICE_PROXY_HTTP_URL, {}, { disableMetrics: true }, metrics)
+      await service.get('/foo')
+
+      assert.strictSame(observedMetrics, expectedObservedMetrics)
+
+      myServiceNameScope.done()
+      assert.end()
+    })
+
     innerTest.test('metrics are NOT collected if disabled on request level', async assert => {
       observedMetrics = null
       const expectedObservedMetrics = null

--- a/tests/httpClient.test.js
+++ b/tests/httpClient.test.js
@@ -1243,6 +1243,137 @@ tap.test('httpClient', test => {
     innerTest.end()
   })
 
+  test.test('httpClient metrics', innerTest => {
+    const delay = 20
+    let observedMetrics
+    const metrics = {
+      requestDuration: {
+        observe: (labels, value) => {
+          observedMetrics = {
+            labels,
+            value,
+          }
+        },
+      },
+    }
+
+    innerTest.test('metrics are NOT collected if NOT enabled on proxy level - request ok', async assert => {
+      observedMetrics = null
+      const expectedObservedMetrics = null
+      const myServiceNameScope = nock(MY_AWESOME_SERVICE_PROXY_HTTP_URL)
+        .get('/foo')
+        .reply(200, { the: 'response' })
+
+      const service = new HttpClient(MY_AWESOME_SERVICE_PROXY_HTTP_URL)
+      await service.get('/foo')
+
+      assert.equal(observedMetrics, expectedObservedMetrics)
+
+      myServiceNameScope.done()
+      assert.end()
+    })
+
+    innerTest.test('metrics are collected if enabled - request ok', async assert => {
+      observedMetrics = null
+      const expectedObservedMetrics = {
+        labels: {
+          method: 'GET',
+          url: '/foo',
+          baseUrl: MY_AWESOME_SERVICE_PROXY_HTTP_URL,
+          statusCode: 200,
+        },
+      }
+      const myServiceNameScope = nock(MY_AWESOME_SERVICE_PROXY_HTTP_URL)
+        .get('/foo')
+        .delay(delay)
+        .reply(200, { the: 'response' })
+
+      const service = new HttpClient(MY_AWESOME_SERVICE_PROXY_HTTP_URL, {}, {}, metrics)
+      await service.get('/foo')
+
+      assert.strictSame(observedMetrics.labels, expectedObservedMetrics.labels)
+      assert.ok(observedMetrics.value > delay)
+
+      myServiceNameScope.done()
+      assert.end()
+    })
+
+    innerTest.test('metrics are collected if enabled - request ko', async assert => {
+      observedMetrics = null
+      const expectedObservedMetrics = {
+        labels: {
+          method: 'GET',
+          url: '/foo',
+          baseUrl: MY_AWESOME_SERVICE_PROXY_HTTP_URL,
+          statusCode: 500,
+        },
+      }
+      const myServiceNameScope = nock(MY_AWESOME_SERVICE_PROXY_HTTP_URL)
+        .get('/foo')
+        .delay(delay)
+        .reply(500, { the: 'response' })
+
+      const service = new HttpClient(MY_AWESOME_SERVICE_PROXY_HTTP_URL, {}, {}, metrics)
+
+      try {
+        await service.get('/foo')
+        assert.fail()
+      } catch (error) {
+        assert.pass()
+      }
+
+      assert.strictSame(observedMetrics.labels, expectedObservedMetrics.labels)
+      assert.ok(observedMetrics.value > delay)
+
+      myServiceNameScope.done()
+      assert.end()
+    })
+
+    innerTest.test('metrics are collected with option urlLabel', async assert => {
+      observedMetrics = null
+      const expectedObservedMetrics = {
+        labels: {
+          method: 'GET',
+          url: '/foo/:user-parameter',
+          baseUrl: MY_AWESOME_SERVICE_PROXY_HTTP_URL,
+          statusCode: 200,
+        },
+      }
+      const myServiceNameScope = nock(MY_AWESOME_SERVICE_PROXY_HTTP_URL)
+        .get('/foo/1234')
+        .delay(delay)
+        .reply(200, { the: 'response' })
+
+      const service = new HttpClient(MY_AWESOME_SERVICE_PROXY_HTTP_URL, {}, {}, metrics)
+      await service.get('/foo/1234', { metrics: { urlLabel: '/foo/:user-parameter' } })
+
+      assert.strictSame(observedMetrics.labels, expectedObservedMetrics.labels)
+      assert.ok(observedMetrics.value > delay)
+
+      myServiceNameScope.done()
+      assert.end()
+    })
+
+    innerTest.test('metrics are NOT collected if disabled on request level', async assert => {
+      observedMetrics = null
+      const expectedObservedMetrics = null
+      const myServiceNameScope = nock(MY_AWESOME_SERVICE_PROXY_HTTP_URL)
+        .get('/foo')
+        .delay(delay)
+        .reply(200, { the: 'response' })
+
+      const service = new HttpClient(MY_AWESOME_SERVICE_PROXY_HTTP_URL, {}, {}, metrics)
+      await service.get('/foo', { metrics: { disabled: true } })
+
+      assert.strictSame(observedMetrics, expectedObservedMetrics)
+
+      myServiceNameScope.done()
+      assert.end()
+    })
+
+    innerTest.end()
+  })
+
   test.test('returnAs: unknown', async assert => {
     const service = new HttpClient(MY_AWESOME_SERVICE_PROXY_HTTP_URL)
     try {
@@ -2128,6 +2259,31 @@ tap.test('httpClient', test => {
 
       myServiceNameScope.done()
     })
+  })
+
+  test.test('httpClientMetrics are registered if enabled', async innerTest => {
+    const USERID_HEADER_KEY = 'userid-header-key'
+    const GROUPS_HEADER_KEY = 'groups-header-key'
+    const CLIENTTYPE_HEADER_KEY = 'clienttype-header-key'
+    const BACKOFFICE_HEADER_KEY = 'backoffice-header-key'
+    const MICROSERVICE_GATEWAY_SERVICE_NAME = 'microservice-gateway'
+
+    const baseEnv = {
+      USERID_HEADER_KEY,
+      GROUPS_HEADER_KEY,
+      CLIENTTYPE_HEADER_KEY,
+      BACKOFFICE_HEADER_KEY,
+      MICROSERVICE_GATEWAY_SERVICE_NAME,
+      ENABLE_HTTP_CLIENT_METRICS: true,
+    }
+    const stream = split(JSON.parse)
+    const fastify = await lc39('./tests/services/http-client.js', {
+      logLevel: 'trace',
+      stream,
+      envVariables: baseEnv,
+    })
+
+    innerTest.equal(typeof fastify.httpClientMetrics?.requestDuration, 'object')
   })
 
   test.end()

--- a/tests/httpClient.test.js
+++ b/tests/httpClient.test.js
@@ -323,7 +323,7 @@ tap.test('httpClient', test => {
       assert.end()
     })
 
-    innerTest.test('on 500 response includes duration property', async assert => {
+    innerTest.test('on not allowed statusCode error includes duration property', async assert => {
       const responseDelay = 50
       const myServiceNameScope = nock(MY_AWESOME_SERVICE_PROXY_HTTP_URL)
         .replyContentLength()

--- a/tests/serviceProxy.test.js
+++ b/tests/serviceProxy.test.js
@@ -153,6 +153,7 @@ tap.test('serviceProxy', test => {
     const fastify = await setupFastify('./tests/services/service-proxy.js', {
       ...baseEnv,
       ADDITIONAL_HEADERS_TO_PROXY,
+      ENABLE_HTTP_CLIENT_METRICS: true,
     })
     const response = await fastify.inject({
       method: 'POST',


### PR DESCRIPTION
Add metrics to collect http client request duration.
The metric is enabled at service level by mean of the variable `ENABLE_HTTP_CLIENT_METRICS` (default: false).
The metric can be enabled at service level and disabled for specific proxy or request by mean of proxy/request options.
The url metrics label can be set by request options (default is request url) -> this is to prevent too many labels values for `url`  when calling a parameterized url (e.g: /riders/:id).

[related pr](https://github.com/mia-platform/custom-plugin-lib/pull/278)

#### Checklist

- [x] your branch will not cause merge conflict with `master`
- [x] run `npm test`
- [x] tests are included
- [x] the documentation is updated or integrated accordingly with your changes
- [x] the code will follow the lint rules and style of the project
- [x] you are not committing extraneous files or sensible data
