### PR TITLE
Fixed HttpClientBaseOptions

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -128,7 +128,8 @@ declare namespace customPlugin {
     cert?: string,
     key?: string,
     ca?: string,
-    logger?: fastify.FastifyLoggerInstance
+    logger?: fastify.FastifyLoggerInstance,
+    isMiaHeaderInjected?: boolean
   }
   interface BaseHttpClientResponse {
     headers: http.IncomingHttpHeaders
@@ -156,7 +157,6 @@ declare namespace customPlugin {
   interface HttpClientOptions extends HttpClientBaseOptions {
     returnAs?: 'STREAM' | 'JSON' | 'BUFFER';
     validateStatus?: (statusCode: number) => boolean;
-    isMiaHeaderInjected?: boolean;
     errorMessageKey?: string;
     proxy?: HttpClientProxy;
     query?: Record<string, string>;


### PR DESCRIPTION
Fixed the typescript definition of type `HttpClientBaseOptions` which, differently from how it is documented, did not allowed to set the `isMiaHeaderInjected` flag.

#### Checklist

- [x] your branch will not cause merge conflict with `master`
- [x] run `npm test`
- [x] tests are included
- [x] the documentation is updated or integrated accordingly with your changes
- [x] the code will follow the lint rules and style of the project
- [x] you are not committing extraneous files or sensible data
