### PR TITLE
Fixed HttpClientBaseOptions interface

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -16,6 +16,7 @@
 
 import * as fastify from 'fastify'
 import * as http from 'http'
+import * as https from 'https'
 
 import {FormatName} from 'ajv-formats'
 
@@ -128,6 +129,7 @@ declare namespace customPlugin {
     cert?: string,
     key?: string,
     ca?: string,
+    httpsAgent?: https.Agent,
     logger?: fastify.FastifyLoggerInstance,
     isMiaHeaderInjected?: boolean
   }


### PR DESCRIPTION
This library allows to pass an `https.Agent` as base option when using the `getHttpClient` function. Anyway this property was missing in the typescript interface definition. This PR adds the property in the interface.

#### Checklist

- [x] your branch will not cause merge conflict with `master`
- [x] run `npm test`
- [x] tests are included
- [x] the documentation is updated or integrated accordingly with your changes
- [x] the code will follow the lint rules and style of the project
- [x] you are not committing extraneous files or sensible data
