### PR TITLE
added: lodash get & set to prevent type error when lib use axios hooks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+### Fixed
+
+- fixed response & error config.metadata.endTime undefined inside to axios interceptors
+
 ## v7.0.0 - 2024-07-04
 
 ### BREAKING

--- a/lib/httpClient.js
+++ b/lib/httpClient.js
@@ -19,6 +19,7 @@
 const axios = require('axios')
 const httpsClient = require('https')
 const Pino = require('pino')
+const { set, get } = require('lodash')
 
 class HttpClient {
   constructor(baseUrl, requestHeadersToProxy, baseOptions = {}, metrics = {}) {
@@ -249,20 +250,22 @@ function getMetricsOptions(metricsOptions = {}, url, metrics) {
 function decorateResponseWithDuration(axiosInstance) {
   axiosInstance.interceptors.response.use(
     (response) => {
-      response.config.metadata.endTime = new Date()
-      response.duration = response.config.metadata.endTime - response.config.metadata.startTime
+      const endTime = get(response, ['config', 'metadata', 'endTime'], new Date())
+      const startTime = get(response, ['config', 'metadata', 'startTime'])
+      response.duration = endTime - startTime
       return response
     },
     (error) => {
-      error.config.metadata.endTime = new Date()
-      error.duration = error.config.metadata.endTime - error.config.metadata.startTime
+      const endTime = get(error, ['config', 'metadata', 'endTime'], new Date())
+      const startTime = get(error, ['config', 'metadata', 'startTime'])
+      error.duration = endTime - startTime
       return Promise.reject(error)
     }
   )
 
   axiosInstance.interceptors.request.use(
     (config) => {
-      config.metadata = { startTime: new Date() }
+      set(config, ['metadata', 'startTime'], new Date())
       return config
     }, (error) => {
       return Promise.reject(error)

--- a/package.json
+++ b/package.json
@@ -50,6 +50,7 @@
     "ajv-formats": "^2.1.1",
     "axios": "^1.6.7",
     "fastify-plugin": "^4.5.0",
+    "lodash": "^4.17.21",
     "http-errors": "^2.0.0",
     "pino": "^8.0.0",
     "simple-get": "^4.0.1"

--- a/tests/httpClient.test.js
+++ b/tests/httpClient.test.js
@@ -23,15 +23,57 @@ function wait(time) {
   return new Promise(resolve => setTimeout(resolve, time))
 }
 
-tap.test('httpClient', test => {
+tap.only('httpClient', test => {
   nock.disableNetConnect()
+
   test.teardown(() => {
     nock.enableNetConnect()
   })
 
-  test.test('forwarding of mia headers', innerTest => {
+  test.only('forwarding of mia headers', innerTest => {
     const HEADER_MIA_KEY = 'miaheader'
     const HEADER_MIA = { [HEADER_MIA_KEY]: 'foo' }
+
+    innerTest.test('expect to error.duration to be defined', async assert => {
+      const myServiceNameScope = nock(MY_AWESOME_SERVICE_PROXY_HTTP_URL, {
+        reqheaders: {
+          [HEADER_MIA_KEY]: HEADER_MIA[HEADER_MIA_KEY],
+        },
+      })
+        .get('/foo')
+        .reply(500, {})
+
+      const service = new HttpClient(MY_AWESOME_SERVICE_PROXY_HTTP_URL, HEADER_MIA)
+      try {
+        await service.get('/foo')
+      } catch (error) {
+        assert.ok('duration' in error)
+        assert.type(error.duration, 'number')
+      }
+
+      myServiceNameScope.done()
+      assert.end()
+    })
+
+    innerTest.test('expect to response.duration to be defined', async assert => {
+      const myServiceNameScope = nock(MY_AWESOME_SERVICE_PROXY_HTTP_URL, {
+        reqheaders: {
+          [HEADER_MIA_KEY]: HEADER_MIA[HEADER_MIA_KEY],
+        },
+      })
+        .get('/foo')
+        .reply(200, {})
+
+      const service = new HttpClient(MY_AWESOME_SERVICE_PROXY_HTTP_URL, HEADER_MIA)
+      const response = await service.get('/foo')
+
+      assert.equal(response.statusCode, 200)
+      assert.ok('duration' in response)
+      assert.type(response.duration, 'number')
+
+      myServiceNameScope.done()
+      assert.end()
+    })
 
     innerTest.test('injects Mia Header if isMiaHeaderInjected option is missing', async assert => {
       const myServiceNameScope = nock(MY_AWESOME_SERVICE_PROXY_HTTP_URL, {

--- a/tests/httpClient.test.js
+++ b/tests/httpClient.test.js
@@ -23,14 +23,14 @@ function wait(time) {
   return new Promise(resolve => setTimeout(resolve, time))
 }
 
-tap.only('httpClient', test => {
+tap.test('httpClient', test => {
   nock.disableNetConnect()
 
   test.teardown(() => {
     nock.enableNetConnect()
   })
 
-  test.only('forwarding of mia headers', innerTest => {
+  test.test('forwarding of mia headers', innerTest => {
     const HEADER_MIA_KEY = 'miaheader'
     const HEADER_MIA = { [HEADER_MIA_KEY]: 'foo' }
 
@@ -49,10 +49,9 @@ tap.only('httpClient', test => {
       } catch (error) {
         assert.ok('duration' in error)
         assert.type(error.duration, 'number')
+        myServiceNameScope.done()
+        assert.end()
       }
-
-      myServiceNameScope.done()
-      assert.end()
     })
 
     innerTest.test('expect to response.duration to be defined', async assert => {


### PR DESCRIPTION
While observing some logs, strange behavior was noticed from the lib giving type errors given the absence of config in some cases:
```
{
  "type":"Error",
  "message":"Cannot read properties of undefined (reading 'metadata')",
  "stack":"Error: Cannot read properties of undefined (reading 'metadata')\n    at HttpClient.makeCall (/home/node/app/node_modules/@mia-platform/custom-plugin-lib/lib/httpClient.js:148:27)"
}
```